### PR TITLE
fix: correct provider version constraints for backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.88.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.80.3, < 3.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |
 
 ### Modules

--- a/examples/vpc-to-vpc/existing-gateway-connection/version.tf
+++ b/examples/vpc-to-vpc/existing-gateway-connection/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.80.3, < 2.0.0"
+      version = ">= 1.80.3"
     }
   }
 }

--- a/examples/vpc-to-vpc/version.tf
+++ b/examples/vpc-to-vpc/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.88.0"
+      version = ">= 1.80.3"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/vpn_policies/version.tf
+++ b/modules/vpn_policies/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.88.0, < 2.0.0"
+      version = ">= 1.80.3, < 3.0.0"
     }
   }
 }

--- a/modules/vpn_routing/version.tf
+++ b/modules/vpn_routing/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.88.0, < 2.0.0"
+      version = ">= 1.80.3, < 3.0.0"
     }
   }
 }

--- a/tests/resources/version.tf
+++ b/tests/resources/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.49.0, < 2.0.0"
+      version = ">= 1.49.0, < 3.0.0"
     }
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.88.0, < 2.0.0"
+      version = ">= 1.80.3, < 3.0.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
### Description

* This PR reverts the provider version constraint from `>=1.88.0` back to `>=1.83.0` to restore backward compatibility. 
* It also extends the upper bound from `<2.0.0` to `<3.0.0` to support newer provider versions.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

* Restored backward compatibility by reverting provider version constraint ( i.e. `>=1.88.0` to `>=1.83.0`)
* Extended upper bound to `<3.0.0` to support newer provider versions.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
